### PR TITLE
Add the ability to delete list entries with Backspace.

### DIFF
--- a/src/components/NoteList.js
+++ b/src/components/NoteList.js
@@ -118,43 +118,37 @@ class NoteList extends HTMLElement {
      * @param {KeyboardEvent} ev Keypress event
      */
     _keyDown (ev) {
-        if ((ev.key !== 'Enter' && ev.key !='Backspace') || ev.shiftKey) {
+        if ((ev.key !== 'Enter' && ev.key !== 'Backspace') || ev.shiftKey) {
             return;
         }
-        // Get the focused element.
         const el = this.deepActiveElement();
-        if (ev.key == 'Enter') {
+        if (ev.key === 'Enter') {
             ev.preventDefault();
-            // If we're in the header, focus on the text section
             if (el.tagName === 'DT' || el.closest('dt')) {
                 el.nextElementSibling.focus();
 
             // If we're in the text section
-            } else if (el.tagName == 'DD' || el.closest('dd')) {
+            } else if (el.tagName === 'DD' || el.closest('dd')) {
                 if (el.parentNode.host === this.shadowRoot.lastElementChild) {
                     // Last NoteList, so add a new item and focus.
                     const newList = new NoteListItem();
                     this.shadowRoot.appendChild(newList);
                     newList.focus();
-
                 } else {
-                    // Move to the next item.
                     const nextList = el.parentNode.host.nextElementSibling;
                     if (nextList) {
                         nextList.focus();
                     }
                 }
             }
-
-        } else if (ev.key == 'Backspace') {
-            // Do default behavior if cell isn't empty
-            if (el.innerHTML != '') {
+            return;
+        } else if (ev.key === 'Backspace') {
+            if (el.innerText !== '') {
                 return;
             }
-            // If we're in the header
             if (el.tagName === 'DT' || el.closest('dt')) {
                 // If it's not the first NoteList, move to the previous one's text field.
-                if (el.parentNode.host !== this.shadowRoot.children[1]) {
+                if (el.parentNode.host !== this.shadowRoot.querySelector('note-list-item')) {
                     const prevItem = el.parentNode.host.previousElementSibling;
 
                     if (prevItem) {
@@ -162,14 +156,12 @@ class NoteList extends HTMLElement {
                         this.deepActiveElement().nextElementSibling.focus();
 
                         // If both NoteList fields are empty, delete it
-                        if (el.innerHTML == '' && el.nextElementSibling.innerHTML == '' ) {
+                        if (el.innerText === '' && el.nextElementSibling.innerText === '') {
                             el.parentNode.host.remove();
                         }
                     }
                 }
-
-            // if we're in the text section
-            } else if (el.tagName == 'DD' || el.closest('dd')) {
+            } else if (el.tagName === 'DD' || el.closest('dd')) {
                 el.previousElementSibling.focus();
             }
         }

--- a/src/components/NoteList.js
+++ b/src/components/NoteList.js
@@ -126,11 +126,9 @@ class NoteList extends HTMLElement {
             ev.preventDefault();
             if (el.tagName === 'DT' || el.closest('dt')) {
                 el.nextElementSibling.focus();
-
-            // If we're in the text section
             } else if (el.tagName === 'DD' || el.closest('dd')) {
                 if (el.parentNode.host === this.shadowRoot.lastElementChild) {
-                    // Last NoteList, so add a new item and focus.
+                    // Last NoteListItem, so add a new item and focus.
                     const newList = new NoteListItem();
                     this.shadowRoot.appendChild(newList);
                     newList.focus();
@@ -147,7 +145,7 @@ class NoteList extends HTMLElement {
                 return;
             }
             if (el.tagName === 'DT' || el.closest('dt')) {
-                // If it's not the first NoteList, move to the previous one's text field.
+                // If it's not the first NoteListItem, move to the previous one's text field.
                 if (el.parentNode.host !== this.shadowRoot.querySelector('note-list-item')) {
                     const prevItem = el.parentNode.host.previousElementSibling;
 
@@ -155,8 +153,8 @@ class NoteList extends HTMLElement {
                         prevItem.focus();
                         this.deepActiveElement().nextElementSibling.focus();
 
-                        // If both NoteList fields are empty, delete it
-                        if (el.innerText === '' && el.nextElementSibling.innerText === '') {
+                        // If both NoteListItem fields are empty, delete it
+                        if (el.parentNode.host.isEmpty()) {
                             el.parentNode.host.remove();
                         }
                     }

--- a/src/components/NoteListItem.js
+++ b/src/components/NoteListItem.js
@@ -45,14 +45,8 @@ class NoteListItem extends HTMLElement {
         if (!this.hasAttribute('role')) {
             this.setAttribute('role', 'list-item');
         }
-        // add event listeners
-        this.addEventListener('keypress', this._keyPress);
     }
 
-    disconnectedCallback () {
-        // remove event listeners
-        this.removeEventListener('keypress', this._keyPress);
-    }
     /**
      * Get the content (header and text) of the pair.
      * @returns {CharacterNote}
@@ -88,22 +82,6 @@ class NoteListItem extends HTMLElement {
             a = a.shadowRoot.activeElement;
         }
         return a;
-    }
-    /**
-     * Handler: Enter to move through the items.
-     * @param {KeyboardEvent} ev Keypress event
-     */
-    _keyPress (ev) {
-        if (ev.key !== 'Enter' || ev.shiftKey) {
-            return;
-        }
-        const el = this.deepActiveElement();
-        if (el.tagName === 'DT' || el.closest('dt')) {
-            ev.preventDefault();
-            ev.stopPropagation();
-            // focus on the sibling DD
-            this.shadowRoot.querySelector('dd').focus();
-        }
     }
     /**
      * Focus method since HTMLElement doesn't have that by default (I think).

--- a/src/components/NoteListItem.js
+++ b/src/components/NoteListItem.js
@@ -89,6 +89,18 @@ class NoteListItem extends HTMLElement {
     focus () {
         this.shadowRoot.querySelector('dt').focus();
     }
+    /**
+     * Determine whether NoteListItem is empty, ignoring lead and trailing whitespace
+     * @returns true if empty, false otherwise
+     */
+    isEmpty () {
+        let empty = false;
+        if (this.shadowRoot.querySelector('dt').innerText.trim() === '' &&
+                this.shadowRoot.querySelector('dd').innerText.trim() === '') {
+            empty = true;
+        }
+        return empty;
+    }
 }
 
 window.customElements.define('note-list-item', NoteListItem);

--- a/src/components/SimpleList.js
+++ b/src/components/SimpleList.js
@@ -144,15 +144,14 @@ class SimpleList extends HTMLElement {
      * @param {KeyboardEvent} ev Keypress event
      */
     _keyDown (ev) {
-        if ((ev.key !== 'Enter' && ev.key !== 'Backspace' )|| ev.shiftKey) {
+        if ((ev.key !== 'Enter' && ev.key !== 'Backspace') || ev.shiftKey) {
             return;
         }
-        // Get the focused element.
         const el = this.deepActiveElement();
         if (el.tagName !== 'LI' && !el.closest('li')) {
             return;
         }
-        if (ev.key == 'Enter') {
+        if (ev.key === 'Enter') {
             ev.preventDefault();
             // compare the focused elements parent component node (note-list-item) to the last item in the list.
             if (el === this.shadowRoot.lastElementChild) {
@@ -166,14 +165,14 @@ class SimpleList extends HTMLElement {
                     nextItem.focus();
                 }
             }
-        } else if (ev.key == 'Backspace') {
-            // shadowRoot 0th child is a style object, so index 1 is our first textbox
-            if (el !== this.shadowRoot.children[1]) {
-               if (el.innerHTML == "") {
-                   const prevItem = el.previousElementSibling;
-                   prevItem.focus();
-                   el.remove();
-               } 
+            return;
+        } else if (ev.key === 'Backspace') {
+            if (el !== this.shadowRoot.querySelector('li')) {
+                if (el.innerText === '') {
+                    const prevItem = el.previousElementSibling;
+                    prevItem.focus();
+                    el.remove();
+                }
             }
         }
     }

--- a/src/components/SimpleList.js
+++ b/src/components/SimpleList.js
@@ -168,7 +168,7 @@ class SimpleList extends HTMLElement {
             return;
         } else if (ev.key === 'Backspace') {
             if (el !== this.shadowRoot.querySelector('li')) {
-                if (el.innerText === '') {
+                if (el.innerText.trim() === '') {
                     const prevItem = el.previousElementSibling;
                     prevItem.focus();
                     el.remove();

--- a/src/components/SimpleList.js
+++ b/src/components/SimpleList.js
@@ -46,7 +46,7 @@ class SimpleList extends HTMLElement {
             this.setAttribute('role', 'list');
         }
         // add event listeners
-        this.addEventListener('keypress', this._keyPress);
+        this.addEventListener('keydown', this._keyDown);
         this.addEventListener('blur', this._blur);
         this._upgradeProperty('fieldName');
         this._upgradeProperty('subFieldName');
@@ -54,7 +54,7 @@ class SimpleList extends HTMLElement {
 
     disconnectedCallback () {
         // remove event listeners
-        this.removeEventListener('keypress', this._keyPress);
+        this.removeEventListener('keydown', this._keyDown);
         this.removeEventListener('blur', this._blur);
     }
     /**
@@ -143,13 +143,16 @@ class SimpleList extends HTMLElement {
      * Handler: Enter to move through the items or add new ones.
      * @param {KeyboardEvent} ev Keypress event
      */
-    _keyPress (ev) {
-        if (ev.key !== 'Enter' || ev.shiftKey) {
+    _keyDown (ev) {
+        if ((ev.key !== 'Enter' && ev.key !== 'Backspace' )|| ev.shiftKey) {
             return;
         }
         // Get the focused element.
         const el = this.deepActiveElement();
-        if (el.tagName === 'LI' || el.closest('li')) {
+        if (el.tagName !== 'LI' && !el.closest('li')) {
+            return;
+        }
+        if (ev.key == 'Enter') {
             ev.preventDefault();
             // compare the focused elements parent component node (note-list-item) to the last item in the list.
             if (el === this.shadowRoot.lastElementChild) {
@@ -162,6 +165,15 @@ class SimpleList extends HTMLElement {
                 if (nextItem) {
                     nextItem.focus();
                 }
+            }
+        } else if (ev.key == 'Backspace') {
+            // shadowRoot 0th child is a style object, so index 1 is our first textbox
+            if (el !== this.shadowRoot.children[1]) {
+               if (el.innerHTML == "") {
+                   const prevItem = el.previousElementSibling;
+                   prevItem.focus();
+                   el.remove();
+               } 
             }
         }
     }

--- a/src/components/TableEditable.js
+++ b/src/components/TableEditable.js
@@ -54,7 +54,7 @@ class TableEditable extends HTMLElement {
             this.setAttribute('role', 'table');
         }
         // add event listeners
-        this.addEventListener('keypress', this._keyPress);
+        this.addEventListener('keydown', this._keyDown);
         this.addEventListener('blur', this._blur);
         this._upgradeProperty('fieldName');
         // for now the column names are also the keys of the data.
@@ -71,7 +71,7 @@ class TableEditable extends HTMLElement {
 
     disconnectedCallback () {
         // remove event listeners
-        this.removeEventListener('keypress', this._keyPress);
+        this.removeEventListener('keydown', this._keyDown);
         this.removeEventListener('blur', this._blur);
     }
     /**
@@ -167,10 +167,10 @@ class TableEditable extends HTMLElement {
     }
     /**
      * Handler: Enter to move through the items or add new ones.
-     * @param {KeyboardEvent} ev Keypress event
+     * @param {KeyboardEvent} ev Keydown event
      */
-    _keyPress (ev) {
-        if (ev.key !== 'Enter' || ev.shiftKey) {
+    _keyDown (ev) {
+        if ((ev.key !== 'Enter' && ev.key !== 'Backspace') || ev.shiftKey) {
             return;
         }
         // Get the focused element.
@@ -178,26 +178,60 @@ class TableEditable extends HTMLElement {
         if (el.tagName !== 'TD' && !el.closest(`td`)) {
             return;
         }
-        ev.preventDefault();
         const td = el.tagName === 'TD' ? el : el.closest(`td`);
         const row = td.parentElement;
-        // if it's not the last cell, move to the next cell.
-        if (td !== row.lastElementChild) {
-            const nextCell = td.nextElementSibling;
-            if (nextCell) {
-                nextCell.focus();
+        if (ev.key == 'Enter') {
+            ev.preventDefault();
+            // if it's not the last cell, move to the next cell.
+            if (td !== row.lastElementChild) {
+                const nextCell = td.nextElementSibling;
+                if (nextCell) {
+                    nextCell.focus();
+                }
+                return;
             }
-            return;
+            // it is the last cell.
+            // if there is a next row focus its first cell.
+            const nextRow = row.nextElementSibling;
+            if (nextRow) {
+                nextRow.querySelector('td').focus();
+                return;
+            }
+            const newRow = this.addRow();
+            newRow.querySelector('td').focus();
+        } else if (ev.key == 'Backspace') {
+            // do default behavior if cell isn't empty
+            if (td.innerHTML != '') {
+                return;
+            }
+            // if it's not the first cell, move to the previous cell.
+            if (td !== row.firstElementChild) { 
+                const prevCell = td.previousElementSibling;
+                if (prevCell) {
+                    prevCell.focus();
+                }
+                return;
+            }
+            // it is the first cell.
+            // if there is a prev row, move to its last cell, delete current row if it's empty.
+            const prevRow = row.previousElementSibling;
+            if (prevRow) {
+                prevRow.lastElementChild.focus();
+
+                const children = row.children;
+                var delRow = true;
+                for (var i = 0; i < children.length; i++) {
+                    if (children[i].innerHTML != "") {
+                        delRow = false;
+                        break;
+                    }
+                }
+                if (delRow) {
+                    row.remove();
+                }
+                return;
+            } 
         }
-        // it is the last cell.
-        // if there is a next row focus its first cell.
-        const nextRow = row.nextElementSibling;
-        if (nextRow) {
-            nextRow.querySelector('td').focus();
-            return;
-        }
-        const newRow = this.addRow();
-        newRow.querySelector('td').focus();
     }
     /**
      * On blur dispatch an event so the character model can be updated.

--- a/src/components/TableEditable.js
+++ b/src/components/TableEditable.js
@@ -173,16 +173,15 @@ class TableEditable extends HTMLElement {
         if ((ev.key !== 'Enter' && ev.key !== 'Backspace') || ev.shiftKey) {
             return;
         }
-        // Get the focused element.
         const el = this.deepActiveElement();
         if (el.tagName !== 'TD' && !el.closest(`td`)) {
             return;
         }
         const td = el.tagName === 'TD' ? el : el.closest(`td`);
         const row = td.parentElement;
-        if (ev.key == 'Enter') {
+        if (ev.key === 'Enter') {
             ev.preventDefault();
-            // if it's not the last cell, move to the next cell.
+
             if (td !== row.lastElementChild) {
                 const nextCell = td.nextElementSibling;
                 if (nextCell) {
@@ -190,8 +189,6 @@ class TableEditable extends HTMLElement {
                 }
                 return;
             }
-            // it is the last cell.
-            // if there is a next row focus its first cell.
             const nextRow = row.nextElementSibling;
             if (nextRow) {
                 nextRow.querySelector('td').focus();
@@ -199,13 +196,13 @@ class TableEditable extends HTMLElement {
             }
             const newRow = this.addRow();
             newRow.querySelector('td').focus();
-        } else if (ev.key == 'Backspace') {
-            // do default behavior if cell isn't empty
-            if (td.innerHTML != '') {
+            return;
+        } else if (ev.key === 'Backspace') {
+            if (td.innerText !== '') {
                 return;
             }
             // if it's not the first cell, move to the previous cell.
-            if (td !== row.firstElementChild) { 
+            if (td !== row.firstElementChild) {
                 const prevCell = td.previousElementSibling;
                 if (prevCell) {
                     prevCell.focus();
@@ -217,11 +214,10 @@ class TableEditable extends HTMLElement {
             const prevRow = row.previousElementSibling;
             if (prevRow) {
                 prevRow.lastElementChild.focus();
-
                 const children = row.children;
-                var delRow = true;
-                for (var i = 0; i < children.length; i++) {
-                    if (children[i].innerHTML != "") {
+                let delRow = true;
+                for (let i = 0; i < children.length; i++) {
+                    if (children[i].innerHTML !== '') {
                         delRow = false;
                         break;
                     }
@@ -230,7 +226,7 @@ class TableEditable extends HTMLElement {
                     row.remove();
                 }
                 return;
-            } 
+            }
         }
     }
     /**

--- a/src/components/TableEditable.js
+++ b/src/components/TableEditable.js
@@ -198,7 +198,7 @@ class TableEditable extends HTMLElement {
             newRow.querySelector('td').focus();
             return;
         } else if (ev.key === 'Backspace') {
-            if (td.innerText !== '') {
+            if (td.innerText.trim() !== '') {
                 return;
             }
             // if it's not the first cell, move to the previous cell.
@@ -214,18 +214,15 @@ class TableEditable extends HTMLElement {
             const prevRow = row.previousElementSibling;
             if (prevRow) {
                 prevRow.lastElementChild.focus();
-                const children = row.children;
                 let delRow = true;
-                for (let i = 0; i < children.length; i++) {
-                    if (children[i].innerHTML !== '') {
+                row.querySelectorAll('td').forEach((c) => {
+                    if (c.innerText.trim() !== '') {
                         delRow = false;
-                        break;
                     }
-                }
+                });
                 if (delRow) {
                     row.remove();
                 }
-                return;
             }
         }
     }


### PR DESCRIPTION
I get a lot of use out of your tool in my D&D games, and really appreciate the work you've put into it.

While using it, I noticed that there wasn't any way to delete empty list entries that I mistakenly made, so I added the ability to delete blank list items by pressing backspace.

This applies to `SimpleList`, `NoteList`, and `TableEditable` types. 

I also pulled the `KeyPress` logic from `NoteListEntry` up to `NoteList` for simplicity.